### PR TITLE
feat(text search): adding additional config options for lower case and stripping symbols

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -21,6 +21,12 @@ max_attempts_per_artist = 25
 max_attempts_per_artist_textsearch = 25
 max_attempts_per_rg = 15
 
+# Text search processing options
+# Convert artist names to lowercase before text search (e.g., Metallica -> metallica)
+artist_textsearch_lowercase = false
+# Remove symbols and diacritics from artist names (e.g., Café Tacvba -> Cafe Tacvba)
+artist_textsearch_remove_symbols = false
+
 # Circuit breaker settings (stops run if API is completely broken)
 circuit_breaker_threshold = 50
 backoff_factor = 0.5

--- a/config.py
+++ b/config.py
@@ -27,6 +27,10 @@ max_attempts_per_artist = 25
 max_attempts_per_artist_textsearch = 25
 max_attempts_per_rg = 15
 
+# Text search processing options
+artist_textsearch_lowercase = false
+artist_textsearch_remove_symbols = false
+
 # Circuit breaker settings
 circuit_breaker_threshold = 50
 backoff_factor = 0.5
@@ -159,7 +163,9 @@ def load_config(path: str) -> dict:
         "max_attempts_per_artist": cp.getint("probe", "max_attempts_per_artist", fallback=25),
         "max_attempts_per_artist_textsearch": cp.getint("probe", "max_attempts_per_artist_textsearch", fallback=25),
         "max_attempts_per_rg": cp.getint("probe", "max_attempts_per_rg", fallback=15),
-        
+        # Text search processing options
+        "artist_textsearch_lowercase": parse_bool(cp.get("probe", "artist_textsearch_lowercase", fallback="false")),
+        "artist_textsearch_remove_symbols": parse_bool(cp.get("probe", "artist_textsearch_remove_symbols", fallback="false")),
         # Circuit breaker settings
         "circuit_breaker_threshold": cp.getint("probe", "circuit_breaker_threshold", fallback=50),
         "backoff_factor": cp.getfloat("probe", "backoff_factor", fallback=0.5),


### PR DESCRIPTION
I've noticed that I have some really odd named artists in my lidarr instance that come with very specific capitalization and symbols. Knowing how the lidarr cache is case and symbol sensitive, it might make sense to give the user the option to force lowercase and remove symbols from the artist names when building the text search cache. I've run this against my database and it seems to be working well, but if you don't want it, I'll keep it in my fork.