### PR TITLE
Add missing import to fix stats.py

### DIFF
--- a/stats.py
+++ b/stats.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import os
 import sys
 from datetime import datetime
 from typing import Dict


### PR DESCRIPTION
Fixes #18 - "❌ ERROR: Could not read storage: name 'os' is not defined" error when getting stats.

Tested by modifying the file in the docker container directly. Not tested outside of docker.